### PR TITLE
Make text collector folder writable for the group

### DIFF
--- a/golang-github-prometheus-node_exporter.spec
+++ b/golang-github-prometheus-node_exporter.spec
@@ -273,7 +273,7 @@ getent passwd node_exporter > /dev/null || \
             -c "Prometheus node exporter" node_exporter
 mkdir -p /var/lib/node_exporter/textfile_collector
 chgrp node_exporter /var/lib/node_exporter/textfile_collector
-chmod 751 /var/lib/node_exporter/textfile_collector
+chmod 771 /var/lib/node_exporter/textfile_collector
 
 %post
 %if 0%{?rhel} != 6


### PR DESCRIPTION
The applications that are running from their own users should be able to write prom metrics in the text collector directory if they are a member of node exporter group.